### PR TITLE
Get player nbt file from main world.

### DIFF
--- a/CombatTagPlusCompat-v1_7_R3/src/main/java/net/minelink/ctplus/compat/v1_7_R3/NpcPlayerHelperImpl.java
+++ b/CombatTagPlusCompat-v1_7_R3/src/main/java/net/minelink/ctplus/compat/v1_7_R3/NpcPlayerHelperImpl.java
@@ -108,7 +108,7 @@ public final class NpcPlayerHelperImpl implements NpcPlayerHelper {
         Player p = Bukkit.getPlayer(identity.getId());
         if (p != null && p.isOnline()) return;
 
-        WorldNBTStorage worldStorage = (WorldNBTStorage) npcPlayer.getWorld().getDataManager();
+        WorldNBTStorage worldStorage = (WorldNBTStorage) ((CraftWorld)Bukkit.getWorlds().get(0)).getHandle().getDataManager();
         NBTTagCompound playerNbt = worldStorage.getPlayerData(identity.getId().toString());
         if (playerNbt == null) return;
 

--- a/CombatTagPlusCompat-v1_7_R4/src/main/java/net/minelink/ctplus/compat/v1_7_R4/NpcPlayerHelperImpl.java
+++ b/CombatTagPlusCompat-v1_7_R4/src/main/java/net/minelink/ctplus/compat/v1_7_R4/NpcPlayerHelperImpl.java
@@ -147,7 +147,7 @@ public final class NpcPlayerHelperImpl implements NpcPlayerHelper {
         Player p = Bukkit.getPlayer(identity.getId());
         if (p != null && p.isOnline()) return;
 
-        WorldNBTStorage worldStorage = (WorldNBTStorage) npcPlayer.getWorld().getDataManager();
+        WorldNBTStorage worldStorage = (WorldNBTStorage) ((CraftWorld)Bukkit.getWorlds().get(0)).getHandle().getDataManager();
         NBTTagCompound playerNbt = worldStorage.getPlayerData(identity.getId().toString());
         if (playerNbt == null) return;
 

--- a/CombatTagPlusCompat-v1_8_R1/src/main/java/net/minelink/ctplus/compat/v1_8_R1/NpcPlayerHelperImpl.java
+++ b/CombatTagPlusCompat-v1_8_R1/src/main/java/net/minelink/ctplus/compat/v1_8_R1/NpcPlayerHelperImpl.java
@@ -126,7 +126,7 @@ public final class NpcPlayerHelperImpl implements NpcPlayerHelper {
         Player p = Bukkit.getPlayer(identity.getId());
         if (p != null && p.isOnline()) return;
 
-        WorldNBTStorage worldStorage = (WorldNBTStorage) npcPlayer.getWorld().getDataManager();
+        WorldNBTStorage worldStorage = (WorldNBTStorage) ((CraftWorld)Bukkit.getWorlds().get(0)).getHandle().getDataManager();
         NBTTagCompound playerNbt = worldStorage.getPlayerData(identity.getId().toString());
         if (playerNbt == null) return;
 

--- a/CombatTagPlusCompat-v1_8_R2/src/main/java/net/minelink/ctplus/compat/v1_8_R2/NpcPlayerHelperImpl.java
+++ b/CombatTagPlusCompat-v1_8_R2/src/main/java/net/minelink/ctplus/compat/v1_8_R2/NpcPlayerHelperImpl.java
@@ -128,7 +128,7 @@ public final class NpcPlayerHelperImpl implements NpcPlayerHelper {
         Player p = Bukkit.getPlayer(identity.getId());
         if (p != null && p.isOnline()) return;
 
-        WorldNBTStorage worldStorage = (WorldNBTStorage) npcPlayer.getWorld().getDataManager();
+        WorldNBTStorage worldStorage = (WorldNBTStorage) ((CraftWorld)Bukkit.getWorlds().get(0)).getHandle().getDataManager();
         NBTTagCompound playerNbt = worldStorage.getPlayerData(identity.getId().toString());
         if (playerNbt == null) return;
 

--- a/CombatTagPlusCompat-v1_8_R3/src/main/java/net/minelink/ctplus/compat/v1_8_R3/NpcPlayerHelperImpl.java
+++ b/CombatTagPlusCompat-v1_8_R3/src/main/java/net/minelink/ctplus/compat/v1_8_R3/NpcPlayerHelperImpl.java
@@ -128,7 +128,7 @@ public final class NpcPlayerHelperImpl implements NpcPlayerHelper {
         Player p = Bukkit.getPlayer(identity.getId());
         if (p != null && p.isOnline()) return;
 
-        WorldNBTStorage worldStorage = (WorldNBTStorage) npcPlayer.getWorld().getDataManager();
+        WorldNBTStorage worldStorage = (WorldNBTStorage) ((CraftWorld)Bukkit.getWorlds().get(0)).getHandle().getDataManager();
         NBTTagCompound playerNbt = worldStorage.getPlayerData(identity.getId().toString());
         if (playerNbt == null) return;
 


### PR DESCRIPTION
Fixes issue where NBT was null and it wouldn't sync when the player was offline. @Despawned can confirm that this fixes it on FuriousPVP.
