### PR TITLE
Show the opponent's name in tag messages

### DIFF
--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
@@ -189,8 +189,13 @@ public final class Settings {
         return ChatColor.translateAlternateColorCodes('&', message);
     }
 
-    public String getTaggedMessage() {
-        String message = plugin.getConfig().getString("tagged-message", "");
+    public String getTagVictimMessage() {
+        String message = plugin.getConfig().getString("tag-victim-message", "");
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+    
+    public String getTagAttackerMessage() {
+        String message = plugin.getConfig().getString("tag-attacker-message", "");
         return ChatColor.translateAlternateColorCodes('&', message);
     }
 

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
@@ -189,6 +189,11 @@ public final class Settings {
         return ChatColor.translateAlternateColorCodes('&', message);
     }
 
+    public String getTaggedMessage() {
+        String message = plugin.getConfig().getString("tagged-message", "");
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+
     public String getUntagMessage() {
         String message = plugin.getConfig().getString("untag-message", "");
         return ChatColor.translateAlternateColorCodes('&', message);

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/TagListener.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/TagListener.java
@@ -172,24 +172,33 @@ public final class TagListener implements Listener {
 
         Player attacker = event.getAttacker();
         Player victim = event.getVictim();
-        String message = plugin.getSettings().getTaggedMessage();
+        String message;
         
-        // Do nothing if tag message is blank
-        if (!message.isEmpty()) {
-          // Send combat tag notification to victim
-          if (victim != null && !plugin.getTagManager().isTagged(victim.getUniqueId()) &&
-                  !plugin.getSettings().onlyTagAttacker()) {
-              victim.sendMessage(message.replace("{opponent}", attacker.getName()));
-          }
+        // Send combat tag notification to victim
+        if (victim != null && !plugin.getTagManager().isTagged(victim.getUniqueId()) &&
+            !plugin.getSettings().onlyTagAttacker()) {
+            if(attacker != null) {
+                message = plugin.getSettings().getTagVictimMessage();
+                // Do nothing if tag message is blank
+                if (!message.isEmpty()) {
+                    victim.sendMessage(message.replace("{opponent}", attacker.getName()));
+                }
+            } else {
+                message = plugin.getSettings().getTagMessage();
+                // Do nothing if tag message is blank
+                if (!message.isEmpty()) {
+                    victim.sendMessage(message);
+                }
+            }
         }
         
-        message = plugin.getSettings().getTagMessage();
+        message = plugin.getSettings().getTagAttackerMessage();
         // Do nothing if tag message is blank
         if (!message.isEmpty()) {
-          // Send combat tag notification to attacker
-          if (attacker != null && !plugin.getTagManager().isTagged(attacker.getUniqueId())) {
-              attacker.sendMessage(message.replace("{opponent}", victim.getName()));
-          }
+            // Send combat tag notification to attacker
+            if (attacker != null && !plugin.getTagManager().isTagged(attacker.getUniqueId())) {
+                attacker.sendMessage(message.replace("{opponent}", victim.getName()));
+            }
         }
     }
 

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/TagListener.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/TagListener.java
@@ -169,21 +169,27 @@ public final class TagListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void sendTagMessage(PlayerCombatTagEvent event) {
-        // Do nothing if tag message is blank
-        String message = plugin.getSettings().getTagMessage();
-        if (message.isEmpty()) return;
 
-        // Send combat tag notification to victim
-        Player victim = event.getVictim();
-        if (victim != null && !plugin.getTagManager().isTagged(victim.getUniqueId()) &&
-                !plugin.getSettings().onlyTagAttacker()) {
-            victim.sendMessage(message);
-        }
-
-        // Send combat tag notification to attacker
         Player attacker = event.getAttacker();
-        if (attacker != null && !plugin.getTagManager().isTagged(attacker.getUniqueId())) {
-            attacker.sendMessage(message);
+        Player victim = event.getVictim();
+        String message = plugin.getSettings().getTaggedMessage();
+        
+        // Do nothing if tag message is blank
+        if (!message.isEmpty()) {
+          // Send combat tag notification to victim
+          if (victim != null && !plugin.getTagManager().isTagged(victim.getUniqueId()) &&
+                  !plugin.getSettings().onlyTagAttacker()) {
+              victim.sendMessage(message.replace("{opponent}", attacker.getName()));
+          }
+        }
+        
+        message = plugin.getSettings().getTagMessage();
+        // Do nothing if tag message is blank
+        if (!message.isEmpty()) {
+          // Send combat tag notification to attacker
+          if (attacker != null && !plugin.getTagManager().isTagged(attacker.getUniqueId())) {
+              attacker.sendMessage(message.replace("{opponent}", victim.getName()));
+          }
         }
     }
 

--- a/CombatTagPlus/src/main/resources/config.yml
+++ b/CombatTagPlus/src/main/resources/config.yml
@@ -4,8 +4,11 @@ config-version: 18
 # The duration in seconds that both the attacker and victim should be tagged in combat.
 tag-duration: 15
 
-# This message is displayed to both the attacker and victim when newly tagged. Set this to '' to display nothing.
-tag-message: '&cYou have engaged in combat. Type &b/ct &cto check your timer.'
+# This message is displayed to the attacker when newly tagged. Set this to '' to display nothing. {opponent} is the attacker.
+tag-message: '&cYou have engaged in combat with &b{opponent}&c. Type &b/ct &cto check your timer.'
+
+# This message is displayed to the victim when newly tagged. Set this to '' to display nothing. {opponent} is the victim.
+tagged-message: '&cYou have been engaged in combat by &b{opponent}&c. Type &b/ct &cto check your timer.'
 
 # This message is displayed the player when their tag expires. Set this to '' to display nothing.
 untag-message: '&aYou are no longer in combat.'

--- a/CombatTagPlus/src/main/resources/config.yml
+++ b/CombatTagPlus/src/main/resources/config.yml
@@ -1,14 +1,17 @@
 # Don't touch this. It's here to determine whether you need to refresh your config.
-config-version: 18
+config-version: 19
 
 # The duration in seconds that both the attacker and victim should be tagged in combat.
 tag-duration: 15
 
-# This message is displayed to the attacker when newly tagged. Set this to '' to display nothing. {opponent} is the attacker.
-tag-message: '&cYou have engaged in combat with &b{opponent}&c. Type &b/ct &cto check your timer.'
+# This message is displayed to both the attacker and victim when newly tagged if there is no attacker. Set this to '' to display nothing.
+tag-message: '&cYou have engaged in combat. Type &b/ct &cto check your timer.'
 
-# This message is displayed to the victim when newly tagged. Set this to '' to display nothing. {opponent} is the victim.
-tagged-message: '&cYou have been engaged in combat by &b{opponent}&c. Type &b/ct &cto check your timer.'
+# This message is displayed to the attacker when newly tagged. Set this to '' to display nothing. {opponent} is the attacker.
+tag-attacker-message: '&cYou have engaged in combat with &b{opponent}&c. Type &b/ct &cto check your timer.'
+
+# This message is displayed to the victim when newly tagged by another player. Set this to '' to display nothing. {opponent} is the victim.
+tag-victim-message: '&cYou have been engaged in combat by &b{opponent}&c. Type &b/ct &cto check your timer.'
 
 # This message is displayed the player when their tag expires. Set this to '' to display nothing.
 untag-message: '&aYou are no longer in combat.'


### PR DESCRIPTION
This allows players to see and prove who started the fight. Wording is slightly different for victim and attacker, if the attacker is a player.
