### PR TITLE
 * Added - new event classes for untag and npc spawn events

### DIFF
--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/NpcManager.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/NpcManager.java
@@ -2,7 +2,9 @@ package net.minelink.ctplus;
 
 import net.minelink.ctplus.event.NpcDespawnEvent;
 import net.minelink.ctplus.event.NpcDespawnReason;
+import net.minelink.ctplus.event.NpcSpawnEvent;
 import net.minelink.ctplus.task.NpcDespawnTask;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -68,6 +70,9 @@ public final class NpcManager {
             // NOTE: Do not directly access the values in the sound enum, as that can change across versions\
             l.getWorld().playSound(l, EXPLODE_SOUND, 0.9F, 0);
         }
+        
+        NpcSpawnEvent event = new NpcSpawnEvent(npc);
+        Bukkit.getPluginManager().callEvent(event);
 
         // Create and start the NPCs despawn task
         long despawnTime = System.currentTimeMillis() + plugin.getSettings().getNpcDespawnMillis();

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/TagManager.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/TagManager.java
@@ -2,6 +2,8 @@ package net.minelink.ctplus;
 
 import net.minelink.ctplus.compat.api.NpcPlayerHelper;
 import net.minelink.ctplus.event.PlayerCombatTagEvent;
+import net.minelink.ctplus.event.PlayerCombatUntagEvent;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -101,6 +103,12 @@ public final class TagManager {
 
     public boolean untag(UUID playerId) {
         Tag tag = tags.remove(playerId);
+
+        if(tag != null) {
+            PlayerCombatUntagEvent event = new PlayerCombatUntagEvent(playerId);
+            Bukkit.getPluginManager().callEvent(event);
+        }
+        
         return tag != null && !tag.isExpired();
     }
 

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/event/NpcSpawnEvent.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/event/NpcSpawnEvent.java
@@ -1,0 +1,29 @@
+package net.minelink.ctplus.event;
+
+import net.minelink.ctplus.Npc;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public final class NpcSpawnEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Npc npc;
+
+    public NpcSpawnEvent(Npc npc) {
+        this.npc = npc;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public Npc getNpc() {
+        return npc;
+    }
+}

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/event/PlayerCombatUntagEvent.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/event/PlayerCombatUntagEvent.java
@@ -1,0 +1,30 @@
+package net.minelink.ctplus.event;
+
+import java.util.UUID;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public final class PlayerCombatUntagEvent extends Event {
+    private UUID playerId;
+    private static HandlerList handlers = new HandlerList();
+
+    public PlayerCombatUntagEvent(UUID playerId) {
+        this.playerId = playerId;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers()
+    {
+        return handlers;
+    }
+    
+    public UUID getPlayerId()
+    {
+        return playerId;
+    }
+}

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/task/TagUpdateTask.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/task/TagUpdateTask.java
@@ -51,6 +51,9 @@ public final class TagUpdateTask extends BukkitRunnable {
             if (!plugin.getSettings().getUntagMessage().isEmpty()) {
                 player.sendMessage(plugin.getSettings().getUntagMessage());
             }
+
+            plugin.getTagManager().untag(player.getUniqueId());
+
             cancel();
             return;
         }


### PR DESCRIPTION
I added these two events which allowed me to supplement this plugin with one that moved the user into a CombatTag group, allowing for custom combat tag rules in a WorldGuard region.
