### PR TITLE
Update to 1.10

### DIFF
--- a/CombatTagPlus/pom.xml
+++ b/CombatTagPlus/pom.xml
@@ -132,6 +132,12 @@
     </dependency>
     <dependency>
       <groupId>net.minelink</groupId>
+      <artifactId>CombatTagPlusCompat-v1_10_R1</artifactId>
+      <version>1.2.4-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.minelink</groupId>
       <artifactId>CombatTagPlusHook</artifactId>
       <version>1.2.4-SNAPSHOT</version>
       <scope>compile</scope>

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/NpcListener.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/NpcListener.java
@@ -5,6 +5,7 @@ import net.minelink.ctplus.Npc;
 import net.minelink.ctplus.event.NpcDespawnEvent;
 import net.minelink.ctplus.event.NpcDespawnReason;
 import net.minelink.ctplus.task.SafeLogoutTask;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/TagListener.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/TagListener.java
@@ -217,19 +217,20 @@ public final class TagListener implements Listener {
     public void sendTagMessage(PlayerCombatTagEvent event) {
         // Do nothing if tag message is blank
         String message = plugin.getSettings().getTagMessage();
-        if (message.isEmpty()) return;
+        if (message.isEmpty()) { return; }
 
-        // Send combat tag notification to victim
+        Player attacker = event.getAttacker();
         Player victim = event.getVictim();
+        
+        // Send combat tag notification to victim
         if (victim != null && !plugin.getTagManager().isTagged(victim.getUniqueId()) &&
                 !plugin.getSettings().onlyTagAttacker()) {
-            victim.sendMessage(message);
+            victim.sendMessage(message.replace("{opponent}", (attacker != null ? attacker.getName() : "someone") ));
         }
 
         // Send combat tag notification to attacker
-        Player attacker = event.getAttacker();
         if (attacker != null && !plugin.getTagManager().isTagged(attacker.getUniqueId())) {
-            attacker.sendMessage(message);
+            attacker.sendMessage(message.replace("{opponent}", (victim != null ? victim.getName() : "someone")));
         }
     }
 

--- a/CombatTagPlus/src/main/resources/config.yml
+++ b/CombatTagPlus/src/main/resources/config.yml
@@ -4,8 +4,8 @@ config-version: 20
 # The duration in seconds that both the attacker and victim should be tagged in combat.
 tag-duration: 15
 
-# This message is displayed to both the attacker and victim when newly tagged. Set this to '' to display nothing.
-tag-message: '&cYou have engaged in combat. Type &b/ct &cto check your timer.'
+# This message is displayed to both the attacker and victim when newly tagged. Set this to '' to display nothing. {opponent} is the other player.
+tag-message: '&cYou have engaged in combat with &b{opponent}&c. Type &b/ct &cto check your timer.'
 
 # This message is displayed the player when their tag expires. Set this to '' to display nothing.
 untag-message: '&aYou are no longer in combat.'

--- a/CombatTagPlusCompat-v1_10_R1/pom.xml
+++ b/CombatTagPlusCompat-v1_10_R1/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>CombatTagPlusParent</artifactId>
+    <groupId>net.minelink</groupId>
+    <version>1.2.4-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>CombatTagPlusCompat-v1_10_R1</artifactId>
+
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>techcable-repo</id>
+      <url>https://repo.techcable.net/content/groups/public/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.bukkit</groupId>
+      <artifactId>craftbukkit</artifactId>
+      <version>1.10-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.minelink</groupId>
+      <artifactId>CombatTagPlusCompat-API</artifactId>
+      <version>1.2.4-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcNetworkManager.java
+++ b/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcNetworkManager.java
@@ -1,0 +1,100 @@
+package net.minelink.ctplus.compat.v1_10_R1;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.GenericFutureListener;
+import net.minecraft.server.v1_10_R1.EnumProtocol;
+import net.minecraft.server.v1_10_R1.EnumProtocolDirection;
+import net.minecraft.server.v1_10_R1.NetworkManager;
+import net.minecraft.server.v1_10_R1.Packet;
+import net.minecraft.server.v1_10_R1.PacketListener;
+
+import javax.crypto.SecretKey;
+import java.net.SocketAddress;
+
+public final class NpcNetworkManager extends NetworkManager {
+
+    public NpcNetworkManager() {
+        super(EnumProtocolDirection.SERVERBOUND);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext channelhandlercontext) throws Exception {
+
+    }
+
+    @Override
+    public void setProtocol(EnumProtocol enumprotocol) {
+
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext channelhandlercontext) {
+
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext channelhandlercontext, Throwable throwable) {
+
+    }
+
+    @Override
+    protected void a(ChannelHandlerContext channelhandlercontext, Packet packet) {
+
+    }
+
+    @Override
+    public void setPacketListener(PacketListener packetlistener) {
+
+    }
+
+    @Override
+    public void sendPacket(Packet packet) {
+
+    }
+
+    @Override
+    public void sendPacket(Packet packet, GenericFutureListener genericfuturelistener, GenericFutureListener... agenericfuturelistener) {
+
+    }
+
+    @Override
+    public SocketAddress getSocketAddress() {
+        return new SocketAddress() {};
+    }
+
+    @Override
+    public boolean isLocal() {
+        return false;
+    }
+
+    @Override
+    public void a(SecretKey secretkey) {
+
+    }
+
+    @Override
+    public boolean isConnected() {
+        return true;
+    }
+
+    @Override
+    public void stopReading() {
+
+    }
+
+    @Override
+    public void setCompressionLevel(int i) {
+
+    }
+
+    @Override
+    public void handleDisconnection() {
+
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext channelhandlercontext, Packet object) throws Exception {
+
+    }
+
+}

--- a/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayer.java
@@ -1,0 +1,48 @@
+package net.minelink.ctplus.compat.v1_10_R1;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import net.minecraft.server.v1_10_R1.EntityPlayer;
+import net.minecraft.server.v1_10_R1.MinecraftServer;
+import net.minecraft.server.v1_10_R1.PlayerInteractManager;
+import net.minecraft.server.v1_10_R1.WorldServer;
+import net.minelink.ctplus.compat.api.NpcIdentity;
+import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
+import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.UUID;
+
+public final class NpcPlayer extends EntityPlayer {
+
+    private NpcIdentity identity;
+
+    private NpcPlayer(MinecraftServer minecraftserver, WorldServer worldserver, GameProfile gameprofile, PlayerInteractManager playerinteractmanager) {
+        super(minecraftserver, worldserver, gameprofile, playerinteractmanager);
+    }
+
+    public NpcIdentity getNpcIdentity() {
+        return identity;
+    }
+
+    public static NpcPlayer valueOf(Player player) {
+        MinecraftServer minecraftServer = MinecraftServer.getServer();
+        WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
+        PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
+        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+
+        for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
+            gameProfile.getProperties().put(entry.getKey(), entry.getValue());
+        }
+
+        NpcPlayer npcPlayer = new NpcPlayer(minecraftServer, worldServer, gameProfile, playerInteractManager);
+        npcPlayer.identity = new NpcIdentity(player);
+
+        new NpcPlayerConnection(npcPlayer);
+
+        return npcPlayer;
+    }
+
+}

--- a/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayerConnection.java
+++ b/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayerConnection.java
@@ -1,0 +1,173 @@
+package net.minelink.ctplus.compat.v1_10_R1;
+
+import net.minecraft.server.v1_10_R1.EntityPlayer;
+import net.minecraft.server.v1_10_R1.IChatBaseComponent;
+import net.minecraft.server.v1_10_R1.MinecraftServer;
+import net.minecraft.server.v1_10_R1.Packet;
+import net.minecraft.server.v1_10_R1.PacketPlayInAbilities;
+import net.minecraft.server.v1_10_R1.PacketPlayInArmAnimation;
+import net.minecraft.server.v1_10_R1.PacketPlayInBlockDig;
+import net.minecraft.server.v1_10_R1.PacketPlayInBlockPlace;
+import net.minecraft.server.v1_10_R1.PacketPlayInChat;
+import net.minecraft.server.v1_10_R1.PacketPlayInClientCommand;
+import net.minecraft.server.v1_10_R1.PacketPlayInCloseWindow;
+import net.minecraft.server.v1_10_R1.PacketPlayInCustomPayload;
+import net.minecraft.server.v1_10_R1.PacketPlayInEnchantItem;
+import net.minecraft.server.v1_10_R1.PacketPlayInEntityAction;
+import net.minecraft.server.v1_10_R1.PacketPlayInFlying;
+import net.minecraft.server.v1_10_R1.PacketPlayInHeldItemSlot;
+import net.minecraft.server.v1_10_R1.PacketPlayInKeepAlive;
+import net.minecraft.server.v1_10_R1.PacketPlayInResourcePackStatus;
+import net.minecraft.server.v1_10_R1.PacketPlayInSetCreativeSlot;
+import net.minecraft.server.v1_10_R1.PacketPlayInSettings;
+import net.minecraft.server.v1_10_R1.PacketPlayInSpectate;
+import net.minecraft.server.v1_10_R1.PacketPlayInSteerVehicle;
+import net.minecraft.server.v1_10_R1.PacketPlayInTabComplete;
+import net.minecraft.server.v1_10_R1.PacketPlayInTransaction;
+import net.minecraft.server.v1_10_R1.PacketPlayInUpdateSign;
+import net.minecraft.server.v1_10_R1.PacketPlayInUseEntity;
+import net.minecraft.server.v1_10_R1.PacketPlayInWindowClick;
+import net.minecraft.server.v1_10_R1.PlayerConnection;
+
+public final class NpcPlayerConnection extends PlayerConnection {
+
+    public NpcPlayerConnection(EntityPlayer entityplayer) {
+        super(MinecraftServer.getServer(), new NpcNetworkManager(), entityplayer);
+    }
+
+    @Override
+    public void disconnect(String s) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInSteerVehicle packetplayinsteervehicle) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInFlying packetplayinflying) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInBlockDig packetplayinblockdig) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInBlockPlace packetplayinblockplace) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInSpectate packetplayinspectate) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInResourcePackStatus packetplayinresourcepackstatus) {
+
+    }
+
+    @Override
+    public void a(IChatBaseComponent ichatbasecomponent) {
+
+    }
+
+    @Override
+    public void sendPacket(Packet packet) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInHeldItemSlot packetplayinhelditemslot) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInChat packetplayinchat) {
+
+    }
+
+    @Override
+    public void chat(String s, boolean async) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInArmAnimation packetplayinarmanimation) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInEntityAction packetplayinentityaction) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInUseEntity packetplayinuseentity) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInClientCommand packetplayinclientcommand) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInCloseWindow packetplayinclosewindow) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInWindowClick packetplayinwindowclick) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInEnchantItem packetplayinenchantitem) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInSetCreativeSlot packetplayinsetcreativeslot) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInTransaction packetplayintransaction) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInUpdateSign packetplayinupdatesign) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInKeepAlive packetplayinkeepalive) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInAbilities packetplayinabilities) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInTabComplete packetplayintabcomplete) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInSettings packetplayinsettings) {
+
+    }
+
+    @Override
+    public void a(PacketPlayInCustomPayload packetplayincustompayload) {
+
+    }
+
+}

--- a/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayerHelperImpl.java
+++ b/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayerHelperImpl.java
@@ -1,0 +1,204 @@
+package net.minelink.ctplus.compat.v1_10_R1;
+
+import net.minecraft.server.v1_10_R1.EntityPlayer;
+import net.minecraft.server.v1_10_R1.EnumItemSlot;
+import net.minecraft.server.v1_10_R1.FoodMetaData;
+import net.minecraft.server.v1_10_R1.ItemStack;
+import net.minecraft.server.v1_10_R1.MinecraftServer;
+import net.minecraft.server.v1_10_R1.NBTCompressedStreamTools;
+import net.minecraft.server.v1_10_R1.NBTTagCompound;
+import net.minecraft.server.v1_10_R1.NBTTagList;
+import net.minecraft.server.v1_10_R1.Packet;
+import net.minecraft.server.v1_10_R1.PacketPlayOutEntityEquipment;
+import net.minecraft.server.v1_10_R1.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_10_R1.PacketPlayOutPlayerInfo.EnumPlayerInfoAction;
+import net.minecraft.server.v1_10_R1.WorldNBTStorage;
+import net.minecraft.server.v1_10_R1.WorldServer;
+import net.minelink.ctplus.compat.api.NpcIdentity;
+import net.minelink.ctplus.compat.api.NpcPlayerHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+public final class NpcPlayerHelperImpl implements NpcPlayerHelper {
+
+    @Override
+    public Player spawn(Player player) {
+        NpcPlayer npcPlayer = NpcPlayer.valueOf(player);
+        WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
+        Location l = player.getLocation();
+
+        npcPlayer.spawnIn(worldServer);
+        npcPlayer.setPositionRotation(l.getX(), l.getY(), l.getZ(), l.getYaw(), l.getPitch());
+        npcPlayer.playerInteractManager.a(worldServer);
+        npcPlayer.invulnerableTicks = 0;
+
+        for (Object o : MinecraftServer.getServer().getPlayerList().players) {
+            if (!(o instanceof EntityPlayer) || o instanceof NpcPlayer) continue;
+
+            PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.ADD_PLAYER, npcPlayer);
+            ((EntityPlayer) o).playerConnection.sendPacket(packet);
+        }
+
+        worldServer.addEntity(npcPlayer);
+        worldServer.getPlayerChunkMap().addPlayer(npcPlayer);
+
+        return npcPlayer.getBukkitEntity();
+    }
+
+    @Override
+    public void despawn(Player player) {
+        EntityPlayer entity = ((CraftPlayer) player).getHandle();
+
+        if (!(entity instanceof NpcPlayer)) {
+            throw new IllegalArgumentException();
+        }
+
+        for (Object o : MinecraftServer.getServer().getPlayerList().players) {
+            if (!(o instanceof EntityPlayer) || o instanceof NpcPlayer) continue;
+
+            PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, entity);
+            ((EntityPlayer) o).playerConnection.sendPacket(packet);
+        }
+
+        WorldServer worldServer = MinecraftServer.getServer().getWorldServer(entity.dimension);
+        worldServer.removeEntity(entity);
+        worldServer.getPlayerChunkMap().removePlayer(entity);
+    }
+
+    @Override
+    public boolean isNpc(Player player) {
+        return ((CraftPlayer) player).getHandle() instanceof NpcPlayer;
+    }
+
+    @Override
+    public NpcIdentity getIdentity(Player player) {
+        if (!isNpc(player)) {
+            throw new IllegalArgumentException();
+        }
+
+        return ((NpcPlayer) ((CraftPlayer) player).getHandle()).getNpcIdentity();
+    }
+
+    @Override
+    public void updateEquipment(Player player) {
+        EntityPlayer entity = ((CraftPlayer) player).getHandle();
+
+        if (!(entity instanceof NpcPlayer)) {
+            throw new IllegalArgumentException();
+        }
+
+        Location l = player.getLocation();
+        int rangeSquared = 512 * 512;
+
+        for (EnumItemSlot slot : EnumItemSlot.values()) {
+            ItemStack item = entity.getEquipment(slot);
+            if (item == null) continue;
+
+            Packet packet = new PacketPlayOutEntityEquipment(entity.getId(), slot, item);
+
+            for (Object o : entity.world.players) {
+                if (!(o instanceof EntityPlayer)) continue;
+
+                EntityPlayer p = (EntityPlayer) o;
+                Location loc = p.getBukkitEntity().getLocation();
+                if (l.getWorld().equals(loc.getWorld()) && l.distanceSquared(loc) <= rangeSquared) {
+                    p.playerConnection.sendPacket(packet);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void syncOffline(Player player) {
+        EntityPlayer entity = ((CraftPlayer) player).getHandle();
+
+        if (!(entity instanceof NpcPlayer)) {
+            throw new IllegalArgumentException();
+        }
+
+        NpcPlayer npcPlayer = (NpcPlayer) entity;
+        NpcIdentity identity = npcPlayer.getNpcIdentity();
+        Player p = Bukkit.getPlayer(identity.getId());
+        if (p != null && p.isOnline()) return;
+
+        WorldNBTStorage worldStorage = (WorldNBTStorage) ((CraftWorld) Bukkit.getWorlds().get(0)).getHandle().getDataManager();
+        NBTTagCompound playerNbt = worldStorage.getPlayerData(identity.getId().toString());
+        if (playerNbt == null) return;
+
+        // foodTickTimer is now private in 1.8.3
+        Field foodTickTimerField;
+        int foodTickTimer;
+
+        try {
+            foodTickTimerField = FoodMetaData.class.getDeclaredField("foodTickTimer");
+            foodTickTimerField.setAccessible(true);
+            foodTickTimer = foodTickTimerField.getInt(entity.getFoodData());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        playerNbt.setShort("Air", (short) entity.getAirTicks());
+        playerNbt.setFloat("HealF", entity.getHealth());
+        playerNbt.setShort("Health", (short) ((int) Math.ceil((double) entity.getHealth())));
+        playerNbt.setFloat("AbsorptionAmount", entity.getAbsorptionHearts());
+        playerNbt.setInt("XpTotal", entity.expTotal);
+        playerNbt.setInt("foodLevel", entity.getFoodData().foodLevel);
+        playerNbt.setInt("foodTickTimer", foodTickTimer);
+        playerNbt.setFloat("foodSaturationLevel", entity.getFoodData().saturationLevel);
+        playerNbt.setFloat("foodExhaustionLevel", entity.getFoodData().exhaustionLevel);
+        playerNbt.setShort("Fire", (short) entity.fireTicks);
+        playerNbt.set("Inventory", npcPlayer.inventory.a(new NBTTagList()));
+
+        File file1 = new File(worldStorage.getPlayerDir(), identity.getId().toString() + ".dat.tmp");
+        File file2 = new File(worldStorage.getPlayerDir(), identity.getId().toString() + ".dat");
+
+        try {
+            NBTCompressedStreamTools.a(playerNbt, new FileOutputStream(file1));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to save player data for " + identity.getName(), e);
+        }
+
+        if ((!file2.exists() || file2.delete()) && !file1.renameTo(file2)) {
+            throw new RuntimeException("Failed to save player data for " + identity.getName());
+        }
+    }
+
+    @Override
+    public void createPlayerList(Player player) {
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+
+        for (WorldServer worldServer : MinecraftServer.getServer().worlds) {
+            for (Object o : worldServer.players) {
+                if (!(o instanceof NpcPlayer)) continue;
+
+                NpcPlayer npcPlayer = (NpcPlayer) o;
+                PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.ADD_PLAYER, npcPlayer);
+                p.playerConnection.sendPacket(packet);
+            }
+        }
+    }
+
+    @Override
+    public void removePlayerList(Player player) {
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+
+        for (WorldServer worldServer : MinecraftServer.getServer().worlds) {
+            for (Object o : worldServer.players) {
+                if (!(o instanceof NpcPlayer)) continue;
+
+                NpcPlayer npcPlayer = (NpcPlayer) o;
+                PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, npcPlayer);
+                p.playerConnection.sendPacket(packet);
+            }
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <module>CombatTagPlusCompat-v1_8_R3</module>
     <module>CombatTagPlusCompat-v1_9_R1</module>
     <module>CombatTagPlusCompat-v1_9_R2</module>
+    <module>CombatTagPlusCompat-v1_10_R1</module>
     <module>CombatTagPlusHook</module>
     <module>CombatTagPlusFactions-v1_6</module>
     <module>CombatTagPlusFactions-v1_8</module>


### PR DESCRIPTION
Does what https://github.com/MinelinkNetwork/CombatTagPlus/commit/9ae862aa2ae28df06c204561b7b3f1bfddf3530a did, but for 1.10 instead.

The only actual code change is that I removed the method here:

https://github.com/MinelinkNetwork/CombatTagPlus/blob/master/CombatTagPlusCompat-v1_9_R2/src/main/java/net/minelink/ctplus/compat/v1_9_R2/NpcPlayerConnection.java#L39

, because apparently that part of the API was changed and the NMS superclass no longer has a c() method. 

I did not test this ingame yet, but it compiles fine.
