### PR TITLE
Added option to generate random UUID or use the player UUID for NPC

### DIFF
--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/NpcNameGeneratorImpl.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/NpcNameGeneratorImpl.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.Random;
+import java.util.UUID;
 
 public final class NpcNameGeneratorImpl implements NpcNameGenerator {
 
@@ -18,7 +19,7 @@ public final class NpcNameGeneratorImpl implements NpcNameGenerator {
     }
 
     @Override
-    public String generate(Player player) {
+    public String generateName(Player player) {
         if (!plugin.getSettings().generateRandomName()) {
             return player.getName();
         }
@@ -34,6 +35,15 @@ public final class NpcNameGeneratorImpl implements NpcNameGenerator {
         }
 
         return name;
+    }
+
+    @Override
+    public UUID generateUUID(Player player) {
+        if (!plugin.getSettings().generateRandomUUID()) {
+            return player.getUniqueId();
+        }
+
+        return UUID.randomUUID();
     }
 
 }

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
@@ -398,4 +398,8 @@ public final class Settings {
     public String getTaggedCommandReply() {
     	return plugin.getConfig().getString("taggedCommandReply");    	
     }
+
+    public boolean generateRandomUUID() {
+        return plugin.getConfig().getBoolean("generate-random-uuid");
+    }
 }

--- a/CombatTagPlus/src/main/resources/config.yml
+++ b/CombatTagPlus/src/main/resources/config.yml
@@ -100,6 +100,9 @@ reset-despawn-time-on-hit: true
 # Generates a random name for the NPC. Turn this off to use the player name (potentially unsafe!)
 generate-random-name: true
 
+# Generates a random UUID for the NPC. Turn this off to use the player UUID (potentially unsafe!)
+generate-random-uuid: true
+
 # This is the prefix to use for the random name. 12 characters max.
 random-name-prefix: PvPLogger
 

--- a/CombatTagPlusCompat-API/src/main/java/net/minelink/ctplus/compat/api/NpcNameGenerator.java
+++ b/CombatTagPlusCompat-API/src/main/java/net/minelink/ctplus/compat/api/NpcNameGenerator.java
@@ -1,9 +1,13 @@
 package net.minelink.ctplus.compat.api;
 
+import java.util.UUID;
+
 import org.bukkit.entity.Player;
 
 public interface NpcNameGenerator {
 
-    public String generate(Player player);
+    public String generateName(Player player);
+
+    public UUID generateUUID(Player player);
 
 }

--- a/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_10_R1/src/main/java/net/minelink/ctplus/compat/v1_10_R1/NpcPlayer.java
@@ -1,19 +1,20 @@
 package net.minelink.ctplus.compat.v1_10_R1;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import net.minecraft.server.v1_10_R1.EntityPlayer;
 import net.minecraft.server.v1_10_R1.MinecraftServer;
 import net.minecraft.server.v1_10_R1.PlayerInteractManager;
 import net.minecraft.server.v1_10_R1.WorldServer;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +32,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_7_R3/src/main/java/net/minelink/ctplus/compat/v1_7_R3/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_7_R3/src/main/java/net/minelink/ctplus/compat/v1_7_R3/NpcPlayer.java
@@ -1,5 +1,11 @@
 package net.minelink.ctplus.compat.v1_7_R3;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_7_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_7_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import net.minecraft.server.v1_7_R3.EntityPlayer;
 import net.minecraft.server.v1_7_R3.MinecraftServer;
 import net.minecraft.server.v1_7_R3.PlayerInteractManager;
@@ -8,12 +14,6 @@ import net.minecraft.util.com.mojang.authlib.GameProfile;
 import net.minecraft.util.com.mojang.authlib.properties.Property;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_7_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_7_R3.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +31,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_7_R4/src/main/java/net/minelink/ctplus/compat/v1_7_R4/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_7_R4/src/main/java/net/minelink/ctplus/compat/v1_7_R4/NpcPlayer.java
@@ -1,5 +1,11 @@
 package net.minelink.ctplus.compat.v1_7_R4;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_7_R4.CraftWorld;
+import org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import net.minecraft.server.v1_7_R4.EntityPlayer;
 import net.minecraft.server.v1_7_R4.MinecraftServer;
 import net.minecraft.server.v1_7_R4.PlayerInteractManager;
@@ -8,12 +14,6 @@ import net.minecraft.util.com.mojang.authlib.GameProfile;
 import net.minecraft.util.com.mojang.authlib.properties.Property;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_7_R4.CraftWorld;
-import org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +31,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_8_R1/src/main/java/net/minelink/ctplus/compat/v1_8_R1/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_8_R1/src/main/java/net/minelink/ctplus/compat/v1_8_R1/NpcPlayer.java
@@ -1,19 +1,20 @@
 package net.minelink.ctplus.compat.v1_8_R1;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_8_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import net.minecraft.server.v1_8_R1.EntityPlayer;
 import net.minecraft.server.v1_8_R1.MinecraftServer;
 import net.minecraft.server.v1_8_R1.PlayerInteractManager;
 import net.minecraft.server.v1_8_R1.WorldServer;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_8_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_8_R1.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +32,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_8_R2/src/main/java/net/minelink/ctplus/compat/v1_8_R2/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_8_R2/src/main/java/net/minelink/ctplus/compat/v1_8_R2/NpcPlayer.java
@@ -1,19 +1,20 @@
 package net.minelink.ctplus.compat.v1_8_R2;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_8_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R2.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import net.minecraft.server.v1_8_R2.EntityPlayer;
 import net.minecraft.server.v1_8_R2.MinecraftServer;
 import net.minecraft.server.v1_8_R2.PlayerInteractManager;
 import net.minecraft.server.v1_8_R2.WorldServer;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_8_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_8_R2.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +32,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_8_R3/src/main/java/net/minelink/ctplus/compat/v1_8_R3/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_8_R3/src/main/java/net/minelink/ctplus/compat/v1_8_R3/NpcPlayer.java
@@ -1,19 +1,20 @@
 package net.minelink.ctplus.compat.v1_8_R3;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import net.minecraft.server.v1_8_R3.EntityPlayer;
 import net.minecraft.server.v1_8_R3.MinecraftServer;
 import net.minecraft.server.v1_8_R3.PlayerInteractManager;
 import net.minecraft.server.v1_8_R3.WorldServer;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +32,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_9_R1/src/main/java/net/minelink/ctplus/compat/v1_9_R1/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_9_R1/src/main/java/net/minelink/ctplus/compat/v1_9_R1/NpcPlayer.java
@@ -1,19 +1,20 @@
 package net.minelink.ctplus.compat.v1_9_R1;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_9_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_9_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import net.minecraft.server.v1_9_R1.EntityPlayer;
 import net.minecraft.server.v1_9_R1.MinecraftServer;
 import net.minecraft.server.v1_9_R1.PlayerInteractManager;
 import net.minecraft.server.v1_9_R1.WorldServer;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_9_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_9_R1.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +32,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/CombatTagPlusCompat-v1_9_R2/src/main/java/net/minelink/ctplus/compat/v1_9_R2/NpcPlayer.java
+++ b/CombatTagPlusCompat-v1_9_R2/src/main/java/net/minelink/ctplus/compat/v1_9_R2/NpcPlayer.java
@@ -1,19 +1,20 @@
 package net.minelink.ctplus.compat.v1_9_R2;
 
+import java.util.Map;
+
+import org.bukkit.craftbukkit.v1_9_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_9_R2.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import net.minecraft.server.v1_9_R2.EntityPlayer;
 import net.minecraft.server.v1_9_R2.MinecraftServer;
 import net.minecraft.server.v1_9_R2.PlayerInteractManager;
 import net.minecraft.server.v1_9_R2.WorldServer;
 import net.minelink.ctplus.compat.api.NpcIdentity;
 import net.minelink.ctplus.compat.api.NpcNameGeneratorFactory;
-import org.bukkit.craftbukkit.v1_9_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_9_R2.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.UUID;
 
 public final class NpcPlayer extends EntityPlayer {
 
@@ -31,7 +32,7 @@ public final class NpcPlayer extends EntityPlayer {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         WorldServer worldServer = ((CraftWorld) player.getWorld()).getHandle();
         PlayerInteractManager playerInteractManager = new PlayerInteractManager(worldServer);
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(NpcNameGeneratorFactory.getNameGenerator().generateUUID(player), NpcNameGeneratorFactory.getNameGenerator().generateName(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
As the `generate-random-name` option, I added `generate-random-uuid`.

Default is `true`.

This feature is useful for exemple on ranking UUID based plugins.
