### PR TITLE
Fixes #85 by adding COMMAND to the list of bypass enums 

### DIFF
--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/PlayerListener.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/PlayerListener.java
@@ -290,6 +290,8 @@ public final class PlayerListener implements Listener {
         switch (event.getCause()) {
             case ENDER_PEARL:
                 return;
+            case COMMAND: // Essentials uses COMMAND instead of PLUGIN
+                          //  Thank you @ExoticCoding -- addresses #85
             case PLUGIN:
             case UNKNOWN:
                 // Optionally untag on PLUGIN or UNKNOWN


### PR DESCRIPTION
Fixes #85 by adding COMMAND to the list of bypass enums associated with the plugin teleport bypass for when player enderpearling should be disabled, but not OP commands and plugin teleports.

Thank you @ExoticCoding for pointing out that Essentials (and others) use COMMAND instead of PLUGIN.